### PR TITLE
chore: revert versions to `0.0.0` before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "description": "A simple keyring snap that integrates with MetaMask accounts.",
   "keywords": [

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring-site",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring-snap",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "A simple keyring snap that integrates with MetaMask accounts.",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "An example of a key management snap for a simple keyring.",
   "proposedName": "MetaMask Snap Simple Keyring",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "UY3Q1sWcrIgozWuISeF/yWEADVcCt0J6dVqCPI/RUbU=",
+    "shasum": "c6tBifuXuW+/BdmSY/EpCrTpmqlL/7juZIJIzejyeFk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
It's required, otherwise the GitHub action will fail.