### PR TITLE
fix: now you don't have to change your defaultSnapOrigin

### DIFF
--- a/packages/site/.env.production
+++ b/packages/site/.env.production
@@ -1,0 +1,1 @@
+SNAP_ORIGIN=npm:@metamask/snap-simple-keyring-snap

--- a/packages/site/.env.production.dist
+++ b/packages/site/.env.production.dist
@@ -1,1 +1,0 @@
-SNAP_ORIGIN=

--- a/packages/site/src/config/snap.ts
+++ b/packages/site/src/config/snap.ts
@@ -2,4 +2,5 @@
  * The snap origin to use.
  * Will default to the local hosted snap if no value is provided in environment.
  */
-export const defaultSnapOrigin = 'npm:@metamask/snap-simple-keyring-snap';
+export const defaultSnapOrigin =
+  process.env.SNAP_ORIGIN ?? `local:http://localhost:8080`;


### PR DESCRIPTION
Previously, to test locally, we had to change the defaultSnapOrigin to `local:http://localhost:8080/`

This is because we misinterpreted the configuration options in template-snap-monorepo.  What they intended was 
```
export const defaultSnapOrigin =
  process.env.SNAP_ORIGIN ?? `local:http://localhost:8080`;
```
and then store `SNAP_ORIGIN` in `.env.production` for the npm version

# Testing

- Run `yarn start`, and the when you install the snap, it should come from http://localhost:8080
- Run `yarn build`, and then in `packages/site` run `yarn dlx serve -s public`
When you install the snap, it should come from `npm:@metamask/snap-simple-keyring-snap`