### PR TITLE
build: update main file (`src/index.ts` -> `dist/bundle.js`)

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "license": "(MIT-0 OR Apache-2.0)",
-  "main": "src/index.ts",
+  "main": "dist/bundle.js",
   "files": [
     "dist/",
     "images/",


### PR DESCRIPTION
As repported internally, we shouldn't ship the `index.ts` file. Instead, the main file should be `dist/bundle.js` ([see examples](https://github.com/MetaMask/snaps/tree/main/packages/examples/packages)).