### PR TITLE
feat: the dApp specifies the Snap version to install

### DIFF
--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -1,11 +1,10 @@
 import { useContext } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { MetamaskActions, MetaMaskContext } from '../hooks';
-import { connectSnap, getThemePreference, getSnap } from '../utils';
-import { HeaderButtons } from './Buttons';
-import { SnapLogo } from './SnapLogo';
-import { Toggle } from './Toggle';
 import packageInfo from '../../package.json';
+import { MetamaskActions, MetaMaskContext } from '../hooks';
+import { connectSnap, getSnap } from '../utils';
+import { HeaderButtons } from './Buttons';
+import { defaultSnapOrigin } from '../config';
 
 const HeaderWrapper = styled.header`
   display: flex;
@@ -39,7 +38,7 @@ const RightContainer = styled.div`
   align-items: center;
 `;
 
-const Version = styled.p`
+const VersionStyle = styled.p`
   margin-top: 1.2rem;
   font-size: 1.6rem;
   margin: auto;
@@ -69,13 +68,38 @@ export const Header = ({
       dispatch({ type: MetamaskActions.SetError, payload: e });
     }
   };
+
+  function Version() {
+    return (
+      <VersionStyle>
+        <div>
+          <b>dApp version: </b>
+          {packageInfo.version}
+        </div>
+
+        {state.installedSnap ? (
+          <div>
+            <b>Snap version installed: </b> {state.installedSnap?.version}
+          </div>
+        ) : (
+          <div>
+            <b>Snap version to install: </b> {packageInfo.version}
+          </div>
+        )}
+
+        {defaultSnapOrigin.startsWith('local') &&
+          '(from ' + defaultSnapOrigin + ')'}
+      </VersionStyle>
+    );
+  }
+
   return (
     <HeaderWrapper>
       <LogoWrapper>
         <Title>🔑 Snap Simple Keyring</Title>
       </LogoWrapper>
       <RightContainer>
-        <Version>Version {packageInfo.version}</Version>
+        <Version />
         <HeaderButtons state={state} onConnectClick={handleConnectClick} />
       </RightContainer>
     </HeaderWrapper>

--- a/packages/site/src/components/Header.tsx
+++ b/packages/site/src/components/Header.tsx
@@ -73,7 +73,7 @@ export const Header = ({
     return (
       <VersionStyle>
         <div>
-          <b>dApp version: </b>
+          <b>Dapp version: </b>
           {packageInfo.version}
         </div>
 

--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -1,3 +1,4 @@
+import packageInfo from '../../package.json';
 import { defaultSnapOrigin } from '../config';
 import { GetSnapsResponse, Snap } from '../types';
 
@@ -20,7 +21,9 @@ export const getSnaps = async (): Promise<GetSnapsResponse> => {
  */
 export const connectSnap = async (
   snapId: string = defaultSnapOrigin,
-  params: Record<'version' | string, unknown> = {},
+  params: Record<'version' | string, unknown> = {
+    version: packageInfo.version,
+  },
 ) => {
   await window.ethereum.request({
     method: 'wallet_requestSnaps',


### PR DESCRIPTION
The dApp specifies the Snap version to install by `version` in `packages/site/package.json`
- If the Snap is not installed, Header gives the version to install
- If the Snap is installed, Header gives the version installed
- Informs you if it will install from localhost

## Multiple Screenshots
![image](https://github.com/MetaMask/snap-simple-keyring/assets/539738/6b40f6b0-cfaa-46d5-a575-f447ccb9a3cc)
![image](https://github.com/MetaMask/snap-simple-keyring/assets/539738/841071a5-3bab-4742-8e2a-a947c8f887b5)
![image](https://github.com/MetaMask/snap-simple-keyring/assets/539738/f7932566-4845-4552-8b83-c816c4e6912c)
![image](https://github.com/MetaMask/snap-simple-keyring/assets/539738/85cf73dc-554e-42a4-a845-9710ad79315d)

## Testing
- manually change the `version` in `package.json`
- `yarn start` will test in localhost mode
- to test in NPM mode, run `yarn build && yarn dlx serve -s public` then visit http://localhost:3000
