### PR TITLE
fix: check if the snap is installed before trying to get its state

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -60,6 +60,10 @@ const Index = () => {
      * @returns The current state of the snap.
      */
     async function getState() {
+      if (!state.installedSnap) {
+        console.log('Snap not installed');
+        return;
+      }
       const accounts = await client.listAccounts();
       const pendingRequests = await client.listRequests();
       const isSynchronous = await isSynchronousMode();


### PR DESCRIPTION
This PR adds a check to see if the snap is installed & connected before trying to get the snap's state, otherwise MetaMask will throw the following error:

```text
MetaMask - RPC Error: Unauthorized to perform action. Try requesting the required permission(s) first.
...
{
    "code": 4100,
    "message": "Unauthorized to perform action. Try requesting the required permission(s) first. ...",
    "data": {
        "origin": "http://localhost:8000",
        "method": "wallet_snap"
    }
}
```