### PR TITLE
ui: fix the private key format in the import account placeholder

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -152,7 +152,7 @@ const Index = () => {
           value: privateKey,
           type: InputType.TextField,
           placeholder:
-            'E.g. 0x0000000000000000000000000000000000000000000000000000000000000000',
+            'E.g. 0000000000000000000000000000000000000000000000000000000000000000',
           onChange: (event: any) => setPrivateKey(event.currentTarget.value),
         },
       ],


### PR DESCRIPTION
The PR removes the `0x` prefix of the private in the placeholder of the "Import Account" method.

**Before:**

<img width="568" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/7d894656-e39c-4aef-a4ff-089f27bac73a">

**After:**

<img width="562" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/fc48e56e-9e35-4099-8134-ac02d48ddeab">