### PR TITLE
fix: remove private key from options after generating key pair

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "035dpNHJSLJBcmKBKomgKsZEexxEyBnbU/iYqDdumWY=",
+    "shasum": "MOUsqF3AS//7rm61xuhfO0saoBr/TvTEPLABpN7r7FI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -81,6 +81,9 @@ export class SimpleKeyring implements Keyring {
       throw new Error(`Account address already in use: ${address}`);
     }
 
+    // The private key should not be stored in the account options since the
+    // account object is exposed to external components, such as MetaMask and
+    // the snap UI.
     if (options?.privateKey) {
       delete options.privateKey;
     }

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -81,6 +81,10 @@ export class SimpleKeyring implements Keyring {
       throw new Error(`Account address already in use: ${address}`);
     }
 
+    if (options?.privateKey) {
+      delete options.privateKey;
+    }
+
     const account: KeyringAccount = {
       id: uuid(),
       options,


### PR DESCRIPTION
<img src="https://github.com/MetaMask/snap-simple-keyring/assets/17601467/7d446687-fe81-4c20-a8c3-d126a8594a86" width="600" />

<img src="https://github.com/MetaMask/snap-simple-keyring/assets/17601467/fbd75553-a343-4e37-abfd-fd05403c5837" width="600" />

fixes https://github.com/MetaMask/accounts-planning/issues/57
