### PR TITLE
fix: add state.installSnap into dep array

### DIFF
--- a/packages/site/src/pages/index.tsx
+++ b/packages/site/src/pages/index.tsx
@@ -74,7 +74,7 @@ const Index = () => {
     }
 
     getState().catch((error) => console.error(error));
-  }, []);
+  }, [state.installedSnap]);
 
   const createAccount = async () => {
     const newAccount = await client.createAccount();


### PR DESCRIPTION
Fixes the issue where existing accounts were not being loaded by adding `state.installSnap` to the dependency array.