### PR TITLE
[Fix] Snap and extension are out of sync

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "6ENm34fAbQ8N6489MEH0/Vm48fZSyrBXHhrtgHiAejE=",
+    "shasum": "Ch+6Kdk6BTTf7oMjvwf+DDfuRstXMqRUZqK2uJODiLk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "d41GJkj+uao0uvUCZNNgRITeBdLFdLZMzt3YxSq5muU=",
+    "shasum": "6ENm34fAbQ8N6489MEH0/Vm48fZSyrBXHhrtgHiAejE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "MOUsqF3AS//7rm61xuhfO0saoBr/TvTEPLABpN7r7FI=",
+    "shasum": "d41GJkj+uao0uvUCZNNgRITeBdLFdLZMzt3YxSq5muU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -138,9 +138,13 @@ export class SimpleKeyring implements Keyring {
   }
 
   async deleteAccount(id: string): Promise<void> {
-    delete this.#state.wallets[id];
     await this.#saveState();
-    await this.#emitEvent(KeyringEvent.AccountDeleted, { id });
+    try {
+      await this.#emitEvent(KeyringEvent.AccountDeleted, { id });
+      delete this.#state.wallets[id];
+    } catch (error) {
+      throwError((error as Error).message);
+    }
   }
 
   async listRequests(): Promise<KeyringRequest[]> {

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -80,7 +80,6 @@ export class SimpleKeyring implements Keyring {
     if (!isUniqueAddress(address, Object.values(this.#state.wallets))) {
       throw new Error(`Account address already in use: ${address}`);
     }
-
     // The private key should not be stored in the account options since the
     // account object is exposed to external components, such as MetaMask and
     // the snap UI.
@@ -88,26 +87,28 @@ export class SimpleKeyring implements Keyring {
       delete options.privateKey;
     }
 
-    const account: KeyringAccount = {
-      id: uuid(),
-      options,
-      address,
-      methods: [
-        EthMethod.PersonalSign,
-        EthMethod.Sign,
-        EthMethod.SignTransaction,
-        EthMethod.SignTypedDataV1,
-        EthMethod.SignTypedDataV3,
-        EthMethod.SignTypedDataV4,
-      ],
-      type: EthAccountType.Eoa,
-    };
-
-    this.#state.wallets[account.id] = { account, privateKey };
-    await this.#saveState();
-    await this.#emitEvent(KeyringEvent.AccountCreated, { account });
-
-    return account;
+    try {
+      const account: KeyringAccount = {
+        id: uuid(),
+        options,
+        address,
+        methods: [
+          EthMethod.PersonalSign,
+          EthMethod.Sign,
+          EthMethod.SignTransaction,
+          EthMethod.SignTypedDataV1,
+          EthMethod.SignTypedDataV3,
+          EthMethod.SignTypedDataV4,
+        ],
+        type: EthAccountType.Eoa,
+      };
+      await this.#emitEvent(KeyringEvent.AccountCreated, { account });
+      this.#state.wallets[account.id] = { account, privateKey };
+      await this.#saveState();
+      return account;
+    } catch (error) {
+      throw new Error((error as Error).message);
+    }
   }
 
   async filterAccountChains(_id: string, chains: string[]): Promise<string[]> {

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -138,10 +138,10 @@ export class SimpleKeyring implements Keyring {
   }
 
   async deleteAccount(id: string): Promise<void> {
-    await this.#saveState();
     try {
       await this.#emitEvent(KeyringEvent.AccountDeleted, { id });
       delete this.#state.wallets[id];
+      await this.#saveState();
     } catch (error) {
       throwError((error as Error).message);
     }


### PR DESCRIPTION
## What 

- resolves https://github.com/MetaMask/accounts-planning/issues/72

## Before

https://github.com/MetaMask/snap-simple-keyring/assets/22918444/ef11c7a0-836e-4d6a-8e04-393019bebfe8


#### Create case
- Clicking create account on the snap resulted in the account being created despite the response of the users approval flow
- if a user denies the account creation then the snap and the extension would be out of sync

#### Remove case
- Clicking remove account on the snap removed the account from the snap and then asked for permission in the extension
- if the user denies the account removal then the snap and the extension would be out of sync

## After
- we ask for permission from the extension first, if it gets accepted then we remove/create the account, if not we throw the `user denied account removal`/`user denied account removal` error


https://github.com/MetaMask/snap-simple-keyring/assets/22918444/e3ff1680-e6a5-4830-bdf4-27734bfcfb88


## How
- moving the delete call into a try catch and only removing it after the call to `await this.#emitEvent(KeyringEvent.AccountDeleted, { id });` has executed without errors. Denying the account removal will [throw an error in the extension](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/lib/snap-keyring/snap-keyring.ts#L133)
- similarly with the create flow, moving the `this.#state.wallets[account.id] = { account, privateKey };` call inside a try catch after we call  `await this.#emitEvent(KeyringEvent.AccountCreated, { account });` allows us to only create the account if the approval is granted


