### PR TITLE
feat: add URL to async approval redirect

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -34,7 +34,7 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '!snap.manifest.json' --check",
     "lint:types": "tsc --noEmit",
     "serve": "mm-snap serve",
-    "start": "mm-snap watch"
+    "start": "NODE_ENV='development' mm-snap watch"
   },
   "dependencies": {
     "@ethereumjs/common": "^3.1.2",

--- a/packages/snap/snap.config.ts
+++ b/packages/snap/snap.config.ts
@@ -9,6 +9,10 @@ const config: SnapConfig = {
     stream: true,
     crypto: true,
   },
+  environment: {
+    DAPP_ORIGIN_PRODUCTION: 'https://metamask.github.io/snap-simple-keyring/',
+    DAPP_ORIGIN_DEVELOPMENT: 'http://localhost:8000/',
+  },
   stats: {
     builtIns: {
       // The following builtins can be ignored. They are used by some of the

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "KzUfxp/ybLKpVQLeMKhbPVyYrHONdkPm45OGEVG7t60=",
+    "shasum": "HrkPu8JZ9i1rG671tJGzoVDS15y4+fVfqyHyBhJieh8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "HrkPu8JZ9i1rG671tJGzoVDS15y4+fVfqyHyBhJieh8=",
+    "shasum": "ujoZmyG45Va5jYUWCfiXQ3K1fBERKMlJFg84w7JVI6A=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "kssvsXB8L+oEb/NqBxaTcTcHW8vvz+XBFJXXuaj3FW0=",
+    "shasum": "KzUfxp/ybLKpVQLeMKhbPVyYrHONdkPm45OGEVG7t60=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/tsconfig.json
+++ b/packages/snap/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "skipLibCheck": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
   "include": ["src/", "snap.config.ts"]
 }

--- a/packages/snap/tsconfig.json
+++ b/packages/snap/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
   },
   "include": ["src/", "snap.config.ts"]
 }


### PR DESCRIPTION
Set env variables to point to the dapp origin. the dapp origin is either `http://localhost:8000/` when the NODE_ENV is in development or `https://metamask.github.io/snap-simple-keyring/{version}/` in prod


This change follows the environment variable pattern set by the [snap cli](https://github.com/MetaMask/snaps/tree/main/packages/snaps-cli#environment)
This PR works alongside https://github.com/MetaMask/metamask-extension/pull/21312

### Demo

https://github.com/MetaMask/snap-simple-keyring/assets/22918444/249358c1-ce15-45e8-9284-ec808d3783fd

