### PR TITLE
feat: add logger utility

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "oLvGW/MF14JATNwdVUEBZNeywJPkqr16xWGqlgBna2g=",
+    "shasum": "HB5rO8cwFqvyY1mda9mT+NmUgcbQcPk3bx4DXAqi2Ys=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "F0lfx0Ngkunq0v5IfHtZe7IAOPPjzOfo+ZKwL7e7eD8=",
+    "shasum": "oLvGW/MF14JATNwdVUEBZNeywJPkqr16xWGqlgBna2g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,8 +21,8 @@
     "snap_dialog": {},
     "endowment:keyring": {
       "allowedOrigins": [
-        "https://metamask.github.io",
-        "http://localhost:8000"
+        "http://localhost:8000",
+        "https://metamask.github.io"
       ]
     },
     "endowment:rpc": {

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "HB5rO8cwFqvyY1mda9mT+NmUgcbQcPk3bx4DXAqi2Ys=",
+    "shasum": "VNDOYSzYQUcT0CRJaj09SiNCCuzPZjymzRmYVQwdVV4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '@metamask/snaps-types';
 
 import { SimpleKeyring } from './keyring';
+import { logger } from './logger';
 import { InternalMethod, originPermissions } from './permissions';
 import { getState } from './stateManagement';
 
@@ -41,6 +42,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({
   origin,
   request,
 }) => {
+  logger.debug(
+    `RPC request (origin="${origin}"):`,
+    JSON.stringify(request, undefined, 2),
+  );
+
   // Check if origin is allowed to call method.
   if (!hasPermission(origin, request.method)) {
     throw new Error(
@@ -68,6 +74,11 @@ export const onKeyringRequest: OnKeyringRequestHandler = async ({
   origin,
   request,
 }) => {
+  logger.debug(
+    `Keyring request (origin="${origin}"):`,
+    JSON.stringify(request, undefined, 2),
+  );
+
   // Check if origin is allowed to call method.
   if (!hasPermission(origin, request.method)) {
     throw new Error(

--- a/packages/snap/src/logger.ts
+++ b/packages/snap/src/logger.ts
@@ -1,0 +1,120 @@
+/**
+ * Logging levels.
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+/**
+ * Log function signature.
+ */
+type LogFunction = (message?: any, ...optionalParams: any[]) => void;
+
+/**
+ * Logger context.
+ */
+type LoggerContext = {
+  threshold: LogLevel;
+  handlers: Record<LogLevel, LogFunction>;
+};
+
+/**
+ * Returns the default logging level.
+ *
+ * @returns The default logging level.
+ */
+function getDefaultLevel(): LogLevel {
+  return process.env.NODE_ENV === 'development'
+    ? LogLevel.DEBUG
+    : LogLevel.WARN;
+}
+
+/**
+ * Logger internal context.
+ */
+const DEFAULT_CONTEXT: LoggerContext = {
+  threshold: getDefaultLevel(),
+  handlers: {
+    [LogLevel.DEBUG]: console.debug,
+    [LogLevel.INFO]: console.info,
+    [LogLevel.WARN]: console.warn,
+    [LogLevel.ERROR]: console.error,
+  },
+} as const;
+
+export class Logger {
+  #context: LoggerContext;
+
+  constructor(context: Partial<LoggerContext> = {}) {
+    this.#context = {
+      ...DEFAULT_CONTEXT,
+      ...context,
+    };
+  }
+
+  /**
+   * Logs a message at the specified level.
+   *
+   * @param level - Log level of the message.
+   * @param message - Message to log.
+   * @param optionalParams - Optional parameters to log.
+   */
+  #log(
+    level: LogLevel = LogLevel.DEBUG,
+    message?: any,
+    ...optionalParams: any[]
+  ): void {
+    const { threshold, handlers } = this.#context;
+    if (level >= threshold) {
+      handlers[level](message, ...optionalParams);
+    }
+  }
+
+  /**
+   * Logs a DEBUG message.
+   *
+   * @param message - Message to log.
+   * @param optionalParams - Optional parameters to log.
+   */
+  debug(message?: any, ...optionalParams: any[]): void {
+    this.#log(LogLevel.DEBUG, message, ...optionalParams);
+  }
+
+  /**
+   * Logs an INFO message.
+   *
+   * @param message - Message to log.
+   * @param optionalParams - Optional parameters to log.
+   */
+  info(message?: any, ...optionalParams: any[]): void {
+    this.#log(LogLevel.INFO, message, ...optionalParams);
+  }
+
+  /**
+   * Logs a WARN message.
+   *
+   * @param message - Message to log.
+   * @param optionalParams - Optional parameters to log.
+   */
+  warn(message?: any, ...optionalParams: any[]): void {
+    this.#log(LogLevel.WARN, message, ...optionalParams);
+  }
+
+  /**
+   * Logs an ERROR message.
+   *
+   * @param message - Message to log.
+   * @param optionalParams - Optional parameters to log.
+   */
+  error(message?: any, ...optionalParams: any[]): void {
+    this.#log(LogLevel.ERROR, message, ...optionalParams);
+  }
+}
+
+/**
+ * Exported logger object.
+ */
+export const logger = new Logger();

--- a/packages/snap/src/logger.ts
+++ b/packages/snap/src/logger.ts
@@ -56,6 +56,15 @@ export class Logger {
   }
 
   /**
+   * Sets the logging level.
+   *
+   * @param level - Log level to set.
+   */
+  setLevel(level: LogLevel): void {
+    this.#context.threshold = level;
+  }
+
+  /**
    * Logs a message at the specified level.
    *
    * @param level - Log level of the message.

--- a/packages/snap/src/stateManagement.ts
+++ b/packages/snap/src/stateManagement.ts
@@ -1,4 +1,5 @@
 import type { KeyringState } from './keyring';
+import { logger } from './logger';
 
 /**
  * Default keyring state.
@@ -19,6 +20,8 @@ export async function getState(): Promise<KeyringState> {
     method: 'snap_manageState',
     params: { operation: 'get' },
   })) as any;
+
+  logger.debug('Retrieved state:', JSON.stringify(state));
 
   return {
     ...defaultState,


### PR DESCRIPTION
## **Description**

This PR adds a logging utility class. It should be used instead of `console.log`.

## **Manual testing steps**

1. Go to your browser's console
2. Enable all logging levels
   ![image](https://github.com/MetaMask/snap-simple-keyring/assets/68558152/c3ea887d-8379-4dba-b5b2-fda8b7f9ae35)
3. Start the Snap with `yarn start`
4. Go to the companion dapp
5. Execute a request
6. Verify that the request payload is logged to the console
7. Stop the Snap
8. Edit the Snap's `package.json` file:
   ```diff
   -"start": "NODE_ENV='development' mm-snap watch"
   +"start": "NODE_ENV='production' mm-snap watch"
   ```
3. Start the Snap with `yarn start`
4. Go to the companion dapp
5. Execute a request
6. Verify that the request payload is **not** logged to the console
