### PR TITLE
fix: sanitize error message when importing invalid private key

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "lM0NbPdy5i6AzqmT8r5QmkW38Me42ShiWlBElaGKohY=",
+    "shasum": "yUrc8ln4kEwsfOwtriwB+gPe9jV/3N0imv2Qb4trAOk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "NzAaL772ZAoM2s6Tui0Rp4jOjaR0aPXx4QV35YKPU0U=",
+    "shasum": "lM0NbPdy5i6AzqmT8r5QmkW38Me42ShiWlBElaGKohY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "yUrc8ln4kEwsfOwtriwB+gPe9jV/3N0imv2Qb4trAOk=",
+    "shasum": "F0lfx0Ngkunq0v5IfHtZe7IAOPPjzOfo+ZKwL7e7eD8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -39,6 +39,7 @@ import {
   serializeTransaction,
   isUniqueAddress,
   throwError,
+  runSensitive,
 } from './util';
 import packageInfo from '../package.json';
 
@@ -249,9 +250,13 @@ export class SimpleKeyring implements Keyring {
     privateKey: string;
     address: string;
   } {
-    const privateKeyBuffer = privateKey
-      ? toBuffer(addHexPrefix(privateKey))
-      : Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
+    const privateKeyBuffer: Buffer = runSensitive(
+      () =>
+        privateKey
+          ? toBuffer(addHexPrefix(privateKey))
+          : Buffer.from(crypto.getRandomValues(new Uint8Array(32))),
+      'Invalid private key',
+    );
 
     if (!isValidPrivate(privateKeyBuffer)) {
       throw new Error('Invalid private key');

--- a/packages/snap/src/util.ts
+++ b/packages/snap/src/util.ts
@@ -55,3 +55,25 @@ export function isEvmChain(chain: string): boolean {
 export function throwError(message: string): never {
   throw new Error(message);
 }
+
+/**
+ * Runs the specified callback and throws an error with the specified message
+ * if it fails.
+ *
+ * This function should be used to run code that may throw error messages that
+ * could expose sensitive information.
+ *
+ * @param callback - Callback to run.
+ * @param message - Error message to throw if the callback fails.
+ * @returns The result of the callback.
+ */
+export function runSensitive<Type>(
+  callback: () => Type,
+  message?: string,
+): Type {
+  try {
+    return callback();
+  } catch (error) {
+    throw new Error(message ?? 'An unexpected error occurred');
+  }
+}


### PR DESCRIPTION
This PR makes our Snap follow this [guideline](https://github.com/MetaMask/keyring-api/blob/main/docs/security.md#sanitize-errors-to-remove-sensitive-information).