### PR TITLE
ui: move "Delete" button into account details

### DIFF
--- a/packages/site/src/components/Buttons.tsx
+++ b/packages/site/src/components/Buttons.tsx
@@ -73,21 +73,28 @@ const ConnectedIndicator = styled.div`
 
 type ActionButtonProps = {
   width?: string;
+  margin?: string;
 };
 
 const ActionButton = styled.button<ActionButtonProps>`
-  width: ${(props) => props.width ?? '95%'};
+  width: ${(props) => props.width};
   background-color: #0376c9;
   border-radius: 999px;
   border: none;
   padding: 5px 20px;
-  margin: 8px 2.5% 8px 8px;
+  margin: ${(props) => props.margin};
 
   &:hover {
     background-color: #0376ff;
+    border: none;
     color: #fff;
   }
 `;
+
+ActionButton.defaultProps = {
+  width: '95%',
+  margin: '8px 8px 8px 8px',
+};
 
 export const InstallMetaMaskButton = () => (
   <Link href="https://metamask.io/" target="_blank">
@@ -166,6 +173,7 @@ export const MethodButton = (props: any) => {
       disabled={props.disabled}
       onClick={props.onClick}
       width={props.width}
+      margin={props.margin}
     >
       {props.label}
     </ActionButton>


### PR DESCRIPTION
This PR moves the "Delete" button into the account details and fixes the right margin.

**Before:**

<img width="497" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/63922641-ba2e-4ed1-b313-223c1f5e22c7">
<img width="500" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/c8f71284-0fcc-422e-91db-b9d67de17973">

**After:**

<img width="500" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/ce2029c7-4516-4b0a-906b-dae00f2c8a50">
<img width="493" alt="image" src="https://github.com/MetaMask/snap-simple-keyring/assets/68558152/1f610d8d-664b-472b-b107-b51d026c0ce4">
