### PR TITLE
build: remove cache before building site

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -4,15 +4,15 @@
   "private": true,
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {
-    "build": "cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build --prefix-paths",
-    "clean": "rimraf public",
+    "build": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby build --prefix-paths",
+    "clean": "rimraf public .cache",
     "lint": "yarn lint:eslint && yarn lint:misc && yarn lint:deps && yarn lint:types",
     "lint:deps": "depcheck",
     "lint:eslint": "eslint . --cache --ext js,jsx,ts,tsx",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --check",
     "lint:types": "tsc --noEmit",
-    "start": "cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
+    "start": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This is a workaround for <https://github.com/gatsbyjs/gatsby/issues/38483> and should be reverted once it's fixed by Gatsby.