### PR TITLE
patch: do no git ignore preinstalled-snap.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .DS_Store
-dist/
+
+# Ignore everything in the dist directory
+dist/*
+packages/snap/dist/*
+
+# Allow only the preinstalled-snap.json in the packages/snap/dist/ folder
+!packages/snap/dist/preinstalled-snap.json
+
 build/
 coverage/
 


### PR DESCRIPTION
This ensures that the pre installed snap.json file is included in the bundle

## testing steps
- run yarn build:snap
- expect: there should be NO changes tracked by git but you should see the files in `packages/snap/dist/bundle.js` and `packages/snap/dist/bundle.js.map`
- run `yarn build-preinstalled-snap`
- expect, there should a newly tracked change for git in `packages/snap/dist/preinstalled-snap.json`
<img width="1370" alt="Screenshot 2024-09-03 at 2 14 36 PM" src="https://github.com/user-attachments/assets/4340cfd7-36ad-449a-9432-c9d2689b2bb7">
