### PR TITLE
patch: Include yarn build-preinstalled-snap in main build steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "lint:misc": "yarn workspaces foreach --parallel --verbose run lint:misc",
     "lint:types": "yarn workspaces foreach --parallel --verbose run lint:types",
     "start": "yarn workspaces foreach --parallel --verbose --interlaced run start",
-    "test": "yarn workspaces foreach --parallel --verbose run test",
-    "build-preinstalled-snap": "node scripts/build-preinstalled-snap.js"
+    "test": "yarn workspaces foreach --parallel --verbose run test"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^12.2.0",

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -24,8 +24,9 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "build": "mm-snap build",
+    "build": "mm-snap build && yarn build-preinstalled-snap",
     "build:clean": "yarn clean && yarn build",
+    "build-preinstalled-snap": "node ../../scripts/build-preinstalled-snap.js",
     "clean": "rimraf dist",
     "lint": "yarn lint:eslint && yarn lint:misc && yarn lint:deps && yarn lint:types",
     "lint:deps": "depcheck",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "euGuIXw57Wfb1sBktAhCRMd6DY8Xl07GOXOg88NF/Bk=",
+    "shasum": "fkofrmUU9Q20QqkT6vKtKpI+MK8s4zkEOwCNV99OfOc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
by building the preinstalled snap in the same step we build the snap, we ensure that we generate the latest `preinstalled-snap.json` and that it will be included in the release.

## Testing
- yarn build
- there should be the following 3 files in your snap/dist folder....
- `packages/snap/dist/bundle.js`
- `packages/snap/dist/bundle.js.map`
- `packages/snap/dist/preinstalled-snap.json`