### PR TITLE
fix: moved build-preinstalled-snap.js script inside snap package

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "mm-snap build && yarn build-preinstalled-snap",
     "build:clean": "yarn clean && yarn build",
-    "build-preinstalled-snap": "node ../../scripts/build-preinstalled-snap.js",
+    "build-preinstalled-snap": "node scripts/build-preinstalled-snap.js",
     "clean": "rimraf dist",
     "lint": "yarn lint:eslint && yarn lint:misc && yarn lint:deps && yarn lint:types",
     "lint:deps": "depcheck",

--- a/packages/snap/scripts/build-preinstalled-snap.js
+++ b/packages/snap/scripts/build-preinstalled-snap.js
@@ -23,9 +23,9 @@ function readFileContents(filePath) {
 }
 
 // Paths to the files
-const bundlePath = require.resolve('../packages/snap/dist/bundle.js');
-const iconPath = require.resolve('../packages/snap/images/icon.svg');
-const manifestPath = require.resolve('../packages/snap/snap.manifest.json');
+const bundlePath = require.resolve('../dist/bundle.js');
+const iconPath = require.resolve('../images/icon.svg');
+const manifestPath = require.resolve('../snap.manifest.json');
 
 // File Contents
 const bundle = readFileContents(bundlePath);
@@ -59,11 +59,11 @@ const preinstalledSnap = {
   manifest: JSON.parse(manifest),
   files: [
     {
-      path: '../packages/snap/images/icon.svg',
+      path: 'images/icon.svg',
       value: icon,
     },
     {
-      path: '../packages/snap/dist/bundle.js',
+      path: 'dist/bundle.js',
       value: bundle,
     },
   ],
@@ -73,10 +73,7 @@ const preinstalledSnap = {
 // Write preinstalled-snap file
 try {
   // Preinstalled Snap File
-  const outputPath = join(
-    __dirname,
-    '../packages/snap/dist/preinstalled-snap.json',
-  );
+  const outputPath = join(__dirname, '..', 'dist/preinstalled-snap.json');
   writeFileSync(outputPath, JSON.stringify(preinstalledSnap, null, 0));
 
   console.log(

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "/m16mIw26LCJzzDArTn0bUQ2d2xH7ctNQFYu3oL6BNs=",
+    "shasum": "b8uwuhXykvk+P4nNBvyMzTRZACKNbyEbdT4NhThkxXc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
## Description

This change moves the script to build the preinstalled snap inside the snaps package in order for paths to be correctly resolved when building the snap from [npm location](https://www.npmjs.com/package/@metamask/snap-simple-keyring-snap?activeTab=readme)