### PR TITLE
fix: Allow the metamask.github.io to call the snap

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "b8uwuhXykvk+P4nNBvyMzTRZACKNbyEbdT4NhThkxXc=",
+    "shasum": "C8//64yWqSRyr3cIKMHUzqoiVeX9raZCJPDpx3Xv3LU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -60,4 +60,24 @@ export const originPermissions = new Map<string, string[]>([
       InternalMethod.IsSynchronousMode,
     ],
   ],
+  [
+    'metamask.github.io',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.ToggleSyncApprovals,
+      InternalMethod.IsSynchronousMode,
+    ],
+  ],
 ]);


### PR DESCRIPTION
This is needed to enable testing on mobile.
![Simulator Screenshot - iPhone 15 - 2024-09-03 at 16 26 10](https://github.com/user-attachments/assets/ea338757-070e-461e-9d90-c55ee3f89112)

eventually mobile will use the [origin instead of hostname](https://github.com/MetaMask/metamask-mobile/issues/11029)
