### PR TITLE
feat: add "metamask.github.io" to `allowedOrigins` in the `endowment:keyring`

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "H01kuLrO9lhRFzLIG56cacmfTz7BcDTW7ww3EF3oceQ=",
+    "shasum": "2OpCL3GJ3cWq+8uIZwxjmYjgn8EvU0h2rOsIXpVC1N4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -20,7 +20,8 @@
   "initialPermissions": {
     "endowment:keyring": {
       "allowedOrigins": [
-        "https://metamask.github.io"
+        "https://metamask.github.io",
+        "metamask.github.io"
       ]
     },
     "endowment:rpc": {


### PR DESCRIPTION
## Description
Adds `"metamask.github.io"` to the [list of allowedOrigins](https://github.com/MetaMask/snap-simple-keyring/blob/main/packages/snap/snap.manifest.json#L22) for the `endowment:keyring` in order to overcome blocker with SnapsController rejecting requests from the domain without the "https://" prefix 