### PR TITLE
chore: make @metamask/snap-simple-keyring-site publishable

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -12,8 +12,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --check",
     "lint:types": "tsc --noEmit",
-    "start": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby develop",
-    "prepublishOnly": "yarn build"
+    "start": "rimraf .cache && cross-env GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
   },
   "files": [
     "public/"


### PR DESCRIPTION
Makes @metamask/snap-simple-keyring-site publishable so we enable local serving in MetaMask e2e tests similar to @metamask/test-dapp.