### PR TITLE
fix: include `public` folder in release cache

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/*/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
 
@@ -50,6 +51,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/*/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Dry Run Publish
@@ -74,6 +76,7 @@ jobs:
         with:
           path: |
             ./packages/*/dist
+            ./packages/*/public
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `./packages/*/public` to the GitHub Actions cache in all publish jobs to persist built public assets.
> 
> - **CI/Release Workflow (`.github/workflows/publish-release.yml`)**:
>   - **Cache**: Include `./packages/*/public` alongside `./packages/*/dist` in `restore-build` steps for `publish-release`, `publish-npm-dry-run`, and `publish-npm` jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b467b320a5fe5afdb90aa4dcb1768280adec82c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->