### PR TITLE
fix: revert "2.0.0 (#165)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring",
-  "version": "2.0.0",
+  "version": "1.1.6",
   "private": true,
   "description": "A simple keyring snap that integrates with MetaMask accounts.",
   "keywords": [

--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- Make @metamask/snap-simple-keyring-site publishable ([#163](https://github.com/MetaMask/snap-simple-keyring/pull/163))
-- Use new CentraNo1 font ([#160](https://github.com/MetaMask/snap-simple-keyring/pull/160))
-- Bump `crypto-browserify@^3.12.1` + `snaps-*` ([#159](https://github.com/MetaMask/snap-simple-keyring/pull/159))
-
 ## [1.1.6]
 
 ### Changed
@@ -166,8 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/snap-simple-keyring/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.6...v2.0.0
+[Unreleased]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.6...HEAD
 [1.1.6]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.2...v1.1.6
 [1.1.2]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.0...v1.1.1

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring-site",
-  "version": "2.0.0",
+  "version": "1.1.6",
   "description": "A snap simple keyring dapp used in MetaMask e2e tests.",
   "license": "(MIT-0 OR Apache-2.0)",
   "scripts": {

--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- Bump `crypto-browserify@^3.12.1` + `snaps-*` ([#159](https://github.com/MetaMask/snap-simple-keyring/pull/159))
-
 ## [1.1.6]
 
 ### Changed
@@ -164,8 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/snap-simple-keyring/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.6...v2.0.0
+[Unreleased]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.6...HEAD
 [1.1.6]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/MetaMask/snap-simple-keyring/compare/v1.1.3...v1.1.4

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snap-simple-keyring-snap",
-  "version": "2.0.0",
+  "version": "1.1.6",
   "description": "A simple keyring snap that integrates with MetaMask accounts.",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "1.1.6",
   "description": "An example of a key management snap for a simple keyring.",
   "proposedName": "MetaMask Simple Snap Keyring",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "bFMN5hlkguPBHNaiusJPWZh6yhFnTShcY1mu0Ko5YMM=",
+    "shasum": "k171gIy5HSi41D2djzZNHyAUydUByBagxYjnq/xhwB0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
This reverts commit 0da933b464705768bd86446bf07cd278381ce761.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts 2.0.0 by downgrading versions to 1.1.6 in packages and manifest, updating changelogs and snap shasum.
> 
> - **Version rollback**:
>   - Set `version` to `1.1.6` in `package.json`, `packages/site/package.json`, `packages/snap/package.json`, and `packages/snap/snap.manifest.json`.
> - **Changelogs**:
>   - Remove `2.0.0` sections; update `[Unreleased]` compare links to start from `v1.1.6` in `packages/site/CHANGELOG.md` and `packages/snap/CHANGELOG.md`.
> - **Snap manifest**:
>   - Update `source.shasum` to `k171gIy5HSi41D2djzZNHyAUydUByBagxYjnq/xhwB0=` in `packages/snap/snap.manifest.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cc6ec7dc00e510cb7f2642fcbf6ad49b738cc13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->