### PR TITLE
chore: bump snaps SDK

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -44,7 +44,7 @@
     "@metamask/eth-sig-util": "^7.0.1",
     "@metamask/keyring-api": "^21.0.0",
     "@metamask/keyring-snap-sdk": "^7.0.0",
-    "@metamask/snaps-sdk": "^6.19.0",
+    "@metamask/snaps-sdk": "7.1.0",
     "@metamask/utils": "^8.1.0",
     "uuid": "^9.0.0"
   },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "JqHSAfhSdIosNdTXR5Pi6lHdO9hTuRSyRE0Q0Tvzaks=",
+    "shasum": "ZmIflRibnpSfxo/UbpxVB7djCzQOAiL/mdEldgZPWXc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -27,6 +27,6 @@
     "snap_manageAccounts": {},
     "snap_manageState": {}
   },
-  "platformVersion": "6.19.0",
+  "platformVersion": "7.1.0",
   "manifestVersion": "0.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3561,7 +3561,7 @@ __metadata:
     "@metamask/keyring-api": ^21.0.0
     "@metamask/keyring-snap-sdk": ^7.0.0
     "@metamask/snaps-cli": ^6.7.0
-    "@metamask/snaps-sdk": ^6.19.0
+    "@metamask/snaps-sdk": 7.1.0
     "@metamask/utils": ^8.1.0
     "@types/node": ^20.6.2
     "@typescript-eslint/eslint-plugin": ^5.33.0
@@ -3679,7 +3679,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^6.15.0, @metamask/snaps-sdk@npm:^6.17.0, @metamask/snaps-sdk@npm:^6.17.1, @metamask/snaps-sdk@npm:^6.19.0":
+"@metamask/snaps-sdk@npm:7.1.0":
+  version: 7.1.0
+  resolution: "@metamask/snaps-sdk@npm:7.1.0"
+  dependencies:
+    "@metamask/key-tree": ^10.1.1
+    "@metamask/providers": ^22.1.0
+    "@metamask/rpc-errors": ^7.0.2
+    "@metamask/superstruct": ^3.2.1
+    "@metamask/utils": ^11.4.0
+  checksum: 9d21b7193ce7dfc388188c9b8ad3983decc3d71f6478af23318933b214a6d42e5e152eb44815a0cdfc9b20eb1cee0a44e87793c3027bcbbdb4d9aa566e8c7743
+  languageName: node
+  linkType: hard
+
+"@metamask/snaps-sdk@npm:^6.15.0, @metamask/snaps-sdk@npm:^6.17.0, @metamask/snaps-sdk@npm:^6.17.1":
   version: 6.19.0
   resolution: "@metamask/snaps-sdk@npm:6.19.0"
   dependencies:
@@ -3777,6 +3790,25 @@ __metadata:
     semver: ^7.5.4
     uuid: ^9.0.1
   checksum: f3befb538783f50ac0573468a44ae1331b39318263fd895ff24119f26c57a7c4ab90d4f8593d13bc558023802a07b031aed555c1a096aee0ab6b7ff4cbaa81e1
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^11.4.0":
+  version: 11.9.0
+  resolution: "@metamask/utils@npm:11.9.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    "@types/lodash": ^4.17.20
+    debug: ^4.3.4
+    lodash: ^4.17.21
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: 467d9c1835dfe9bf9f67af0e0a472ca1805aa7f7a3969f439e4d14d9db2fa9c8da7611c8299c81f65ef6a63cb72725b227bac28080ed467375115c3ad6227d7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
My account snaps based on this repo were having an issue where they seemed to be getting RPC requests without origin, which you'd expect with it being based on an old platform version, but unusually, the backward compatibility wasn't working

@ccharly suggested
> you might be using an old Snap platform version in your manifest, but you're maybe using a keyring-api that requires the origin to be there 

So I updated the platform version to be more 7.x, and then the snaps SDK along with it, and this solved the problem

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades the Snap to the newer Snaps platform and SDK.
> 
> - Bumps `@metamask/snaps-sdk` to `7.1.0` in `package.json` and `yarn.lock`
> - Updates `snap.manifest.json` `platformVersion` to `7.1.0` and refreshes `source.shasum`
> - Lockfile updates reflect new transitive deps (e.g., newer `@metamask/utils` entry)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9287d4848b03c0a9db22eda4d9d224b09bbb116b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->