### PR TITLE
feat: add missing methods

### DIFF
--- a/packages/snap/CHANGELOG.md
+++ b/packages/snap/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement `keyring_setSelectedAccounts` and `keyring_resolveAccountAddress` ([#163](https://github.com/MetaMask/snap-simple-keyring/pull/163))
+  - Required for compatibility with `@metamask/eth-snap-keyring@^22`, which invokes these methods when MetaMask switches the active account or needs to resolve the signer for a request.
+- Allow the `metamask` origin to call `keyring_createAccount`, `keyring_resolveAccountAddress`, and `keyring_setSelectedAccounts` ([#163](https://github.com/MetaMask/snap-simple-keyring/pull/163))
+
 ## [2.0.1]
 
 ### Changed

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/MetaMask/snap-simple-keyring.git"
   },
   "source": {
-    "shasum": "TfeKGNKMSPQqAKQ/IrnOaziMcLqC6tWSjKRWo5YHMLs=",
+    "shasum": "GOVQr60E+i51GtXbwdaFzHmBrDKxwBVoDKUICf6V8HI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/keyring.ts
+++ b/packages/snap/src/keyring.ts
@@ -22,6 +22,7 @@ import type {
   KeyringAccount,
   KeyringEventPayload,
   KeyringRequest,
+  ResolvedAccountAddress,
   SubmitRequestResponse,
 } from '@metamask/keyring-api';
 import {
@@ -31,7 +32,11 @@ import {
   KeyringEvent,
 } from '@metamask/keyring-api';
 import { emitSnapKeyringEvent } from '@metamask/keyring-snap-sdk';
-import { type Json, type JsonRpcRequest } from '@metamask/utils';
+import {
+  type CaipChainId,
+  type Json,
+  type JsonRpcRequest,
+} from '@metamask/utils';
 import { Buffer } from 'buffer';
 import { v4 as uuid } from 'uuid';
 
@@ -49,6 +54,7 @@ export type KeyringState = {
   wallets: Record<string, Wallet>;
   pendingRequests: Record<string, KeyringRequest>;
   useSyncApprovals: boolean;
+  selectedAccounts: string[];
 };
 
 export type Wallet = {
@@ -155,6 +161,53 @@ export class SimpleKeyring implements Keyring {
       await this.#saveState();
     } catch (error) {
       throwError((error as Error).message);
+    }
+  }
+
+  async setSelectedAccounts(accounts: string[]): Promise<void> {
+    this.#state.selectedAccounts = accounts;
+    await this.#saveState();
+  }
+
+  async resolveAccountAddress(
+    scope: CaipChainId,
+    request: JsonRpcRequest,
+  ): Promise<ResolvedAccountAddress | null> {
+    const from = this.#extractFromAddress(request);
+    if (from === undefined) {
+      return null;
+    }
+
+    const wallet = Object.values(this.#state.wallets).find(
+      (entry) => entry.account.address.toLowerCase() === from.toLowerCase(),
+    );
+    if (!wallet) {
+      return null;
+    }
+
+    return { address: `${scope}:${wallet.account.address}` };
+  }
+
+  #extractFromAddress(request: JsonRpcRequest): string | undefined {
+    const params = (request.params ?? []) as Json[];
+    switch (request.method) {
+      case EthMethod.PersonalSign: {
+        const [, from] = params as [string, string];
+        return from;
+      }
+      case EthMethod.SignTransaction: {
+        const [tx] = params as [{ from?: string }];
+        return tx?.from;
+      }
+      case EthMethod.SignTypedDataV1:
+      case EthMethod.SignTypedDataV3:
+      case EthMethod.SignTypedDataV4:
+      case EthMethod.Sign: {
+        const [from] = params as [string];
+        return from;
+      }
+      default:
+        return undefined;
     }
   }
 

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -12,12 +12,15 @@ export const originPermissions = new Map<string, string[]>([
       // Keyring methods
       KeyringRpcMethod.ListAccounts,
       KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
       KeyringRpcMethod.FilterAccountChains,
       KeyringRpcMethod.DeleteAccount,
       KeyringRpcMethod.ListRequests,
       KeyringRpcMethod.GetRequest,
       KeyringRpcMethod.SubmitRequest,
       KeyringRpcMethod.RejectRequest,
+      KeyringRpcMethod.ResolveAccountAddress,
+      KeyringRpcMethod.SetSelectedAccounts,
     ],
   ],
   [

--- a/packages/snap/src/stateManagement.ts
+++ b/packages/snap/src/stateManagement.ts
@@ -8,6 +8,7 @@ const defaultState: KeyringState = {
   wallets: {},
   pendingRequests: {},
   useSyncApprovals: true,
+  selectedAccounts: [],
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds support for the new keyring methods that `@metamask/eth-snap-keyring@^22` invokes against installed snaps:

- `keyring_setSelectedAccounts` — called when MetaMask switches the active account; the snap now persists the selected account IDs in its state.
- `keyring_resolveAccountAddress` — called when MetaMask needs to determine which account a signing request belongs to; the snap inspects the EVM signing request params (`personal_sign`, `eth_sign`, `eth_signTransaction`, `eth_signTypedData_v1/v3/v4`), looks up the matching wallet by address, and returns a CAIP-10 account ID (or `null` if no match).

Without these, the previous version of this snap fails to load in builds running on `eth-snap-keyring@22+` because permission checks reject the new outbound calls and the snap throws on the unimplemented methods, crashing the snap and breaking e2e flows in [`metamask-extension#42334`](https://github.com/MetaMask/metamask-extension/pull/42334).

## Changes

- Implement `setSelectedAccounts` and `resolveAccountAddress` on `SimpleKeyring`.
- Add a `selectedAccounts: string[]` field to `KeyringState` (with default `[]`).
- Grant the `metamask` origin permission to call `keyring_createAccount`, `keyring_resolveAccountAddress`, and `keyring_setSelectedAccounts`.
- Rebuild the snap bundle and update `snap.manifest.json` shasum.

## Notes

- `keyring_createAccounts` (the v2 batch variant) is intentionally **not** implemented here. It is only invoked through the extension's `MultichainAccountService`, which is wired up exclusively for Solana/Bitcoin/Tron account providers. SSK is EVM-only and goes through the singular `keyring_createAccount` path.
- A follow-up release will be needed to bring this fix into the extension's preinstalled snap e2e fixtures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: adds new keyring RPC methods and expands `metamask` origin permissions, which affects how signing requests are mapped to accounts and persisted in snap state.
> 
> **Overview**
> Adds support for MetaMask keyring method calls required by `@metamask/eth-snap-keyring@^22`: implements `keyring_setSelectedAccounts` (persist selected account IDs) and `keyring_resolveAccountAddress` (derive the signing account from EVM request params and return a CAIP-10 address).
> 
> Updates snap state to include `selectedAccounts`, expands `metamask` origin permissions to allow `keyring_createAccount`/`keyring_resolveAccountAddress`/`keyring_setSelectedAccounts`, and refreshes the built snap `shasum` plus changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae665ad892b22940decddac3cbcfeb8eb065612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->