### PR TITLE
feat: update changelog to prep release

### DIFF
--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump bundled snap version reference from `@metamask/snap-simple-keyring-snap@2.0.1` to `@metamask/snap-simple-keyring-snap@2.1.0` ([#XXX](https://github.com/MetaMask/snap-simple-keyring/pull/XXX))
+  - The site embeds the snap's `package.json` version at build time, so this republish is required for consumers to install the new snap version through the dapp.
+
 ## [2.0.1]
 
 ### Changed

--- a/packages/site/CHANGELOG.md
+++ b/packages/site/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump bundled snap version reference from `@metamask/snap-simple-keyring-snap@2.0.1` to `@metamask/snap-simple-keyring-snap@2.1.0` ([#XXX](https://github.com/MetaMask/snap-simple-keyring/pull/XXX))
+- Bump bundled snap version reference from `@metamask/snap-simple-keyring-snap@2.0.1` to `@metamask/snap-simple-keyring-snap@2.1.0` ([#178](https://github.com/MetaMask/snap-simple-keyring/pull/178))
   - The site embeds the snap's `package.json` version at build time, so this republish is required for consumers to install the new snap version through the dapp.
 
 ## [2.0.1]


### PR DESCRIPTION
## Summary

Adds a changelog entry to `packages/site` so the next release publishes a new site version aligned with `@metamask/snap-simple-keyring-snap@2.1.0`.

## Why

The site embeds the snap's `package.json` version at build time:

```ts
// packages/site/src/utils/snap.ts
import snapPackageInfo from '../../../snap/package.json';
// ...
{ version: snapPackageInfo.version }
```

When v2.1.0 of the snap was released in #177, the release tool only bumped the snap package because only `packages/snap/CHANGELOG.md` had `## [Unreleased]` entries. The site stayed at 2.0.1 on npm and still asks consumers to install snap v2.0.1 — which doesn't have the new `keyring_setSelectedAccounts` / `keyring_resolveAccountAddress` methods that `@metamask/eth-snap-keyring@^22` now invokes.

This breaks the `metamask-extension` e2e suite for any flow that installs SSK via the companion site (`create-snap-account`, `create-remove-account-snap`, `snap-account-contract-interaction`, etc.) because the local site dependency resolves to v2.0.1 and the install never matches the v2.1.0 snap fixture.

Adding a `## [Unreleased]` entry to `packages/site/CHANGELOG.md` makes the next release tool run bump and publish a new site version, while leaving the snap untouched (so no snap-registry allowlist update is required).

## Changes

- `packages/site/CHANGELOG.md`: new `### Changed` entry under `## [Unreleased]` describing the bundled snap version reference bump.

## Follow-ups

- Cut a patch release (e.g. 2.1.1) via the `Create Release Pull Request` workflow. The tool will bump and publish only the site; the snap stays at 2.1.0.
- In `metamask-extension#42334`, bump `@metamask/snap-simple-keyring-site` to the new version. No snap fixture changes are needed, the new site bundle still references snap v2.1.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in `packages/site/CHANGELOG.md` to trigger a site republish; no runtime or dependency code is modified.
> 
> **Overview**
> Prepares the next `@metamask/snap-simple-keyring-site` release by adding an **Unreleased** changelog entry noting the bundled snap version reference bump from `@metamask/snap-simple-keyring-snap@2.0.1` to `2.1.0`, ensuring consumers install the updated snap via the dapp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517457f058344a192d6314cd57f48bf35f8dd9c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->