### PR TITLE
chore: add comment explaining package versions

### DIFF
--- a/packages/site/src/utils/snap.ts
+++ b/packages/site/src/utils/snap.ts
@@ -1,4 +1,6 @@
 import snapPackageInfo from '../../../snap/package.json';
+// Snap version is read from the snap package's manifest at build time so the
+// dapp installs whichever snap version was bundled with this site release.
 import { defaultSnapOrigin } from '../config';
 import type { GetSnapsResponse, Snap } from '../types';
 


### PR DESCRIPTION
add comment explaining package versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change that clarifies how the snap version is determined; no runtime behavior or interfaces are modified.
> 
> **Overview**
> Adds an explanatory comment in `packages/site/src/utils/snap.ts` noting that the snap version comes from the bundled snap package manifest at build time, so the dapp installs the snap version shipped with the current site release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b58c06b6efce76d5622f1b2b6e8da3832ecc25e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->